### PR TITLE
Remove double Suggests block in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,11 +22,10 @@ Imports:
     futile.logger (>= 1.4.3),
     matrixStats,
     parallel
-Suggests:
-    ggplot2
 LinkingTo: 
     Rcpp
 Suggests:
+    ggplot2
     roxygen2,
     knitr
 RoxygenNote: 6.0.1


### PR DESCRIPTION
Hi,

When trying to install this package with the following command:
```
install_github("dselivanov/LSHR")
```

I get an error because the `DESCRIPTION` file is malformed:
```
E  checking DESCRIPTION meta-information ...
   Malformed Depends or Suggests or Imports or Enhances field.
   Offending entries:
     Suggests:
   roxygen2
   Entries must be names of packages optionally followed by '<=' or '>=',
   white space, and a valid version number in parentheses.
   
   See section 'The DESCRIPTION file' in the 'Writing R Extensions'
   manual.
```

This PR fixes the `DESCRIPTION` file.